### PR TITLE
Add GitHub Actions workflow for MD to PDF conversion

### DIFF
--- a/.github/workflows/md-to-pdf.yml
+++ b/.github/workflows/md-to-pdf.yml
@@ -1,0 +1,92 @@
+name: Convert Markdown to PDF
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '*.md'
+  workflow_dispatch:
+    inputs:
+      input_file:
+        description: 'Input Markdown file'
+        required: false
+        default: 'yakovenko_python_en.md'
+      output_file:
+        description: 'Output PDF file'
+        required: false
+        default: 'yakovenko_python_en_latest.pdf'
+
+jobs:
+  convert-and-publish:
+    runs-on: ubuntu-latest
+
+    env:
+      INPUT_FILE: ${{ github.event.inputs.input_file || 'yakovenko_python_en.md' }}
+      OUTPUT_FILE: ${{ github.event.inputs.output_file || 'yakovenko_python_en_latest.pdf' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Convert Markdown to PDF
+        uses: docker://pandoc/extra:latest
+        with:
+          args: >-
+            ${{ env.INPUT_FILE }}
+            -o ${{ env.OUTPUT_FILE }}
+            --pdf-engine=xelatex
+            -V geometry:margin=1in
+            -V fontsize=11pt
+            -V linkcolor=blue
+            -V urlcolor=blue
+            --highlight-style=tango
+
+      - name: Upload PDF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: resume-pdf
+          path: ${{ env.OUTPUT_FILE }}
+          retention-days: 90
+
+      - name: Generate branch name
+        id: branch
+        run: |
+          BRANCH_NAME="pdf-update-$(date +'%Y%m%d-%H%M%S')"
+          echo "name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: Create branch and commit PDF
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b ${{ steps.branch.outputs.name }}
+          git add ${{ env.OUTPUT_FILE }}
+          git commit -m "Update PDF: ${{ env.OUTPUT_FILE }}
+
+          Generated from ${{ env.INPUT_FILE }} via Pandoc
+
+          Triggered by: ${{ github.event_name }}
+          Commit: ${{ github.sha }}"
+          git push origin ${{ steps.branch.outputs.name }}
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --title "Update PDF: ${{ env.OUTPUT_FILE }}" \
+            --body "## Automated PDF Generation
+
+          **Source:** \`${{ env.INPUT_FILE }}\`
+          **Output:** \`${{ env.OUTPUT_FILE }}\`
+          **Trigger:** ${{ github.event_name }}
+          **Source commit:** ${{ github.sha }}
+
+          ### Generated with Pandoc
+          - Engine: XeLaTeX
+          - Margins: 1 inch
+          - Font size: 11pt
+
+          ---
+          *This PR was automatically created by the MD to PDF workflow.*" \
+            --reviewer dremdem


### PR DESCRIPTION
## Summary

Implements automated Markdown to PDF conversion using Pandoc per #4.

### Workflow Features

| Feature | Implementation |
|---------|----------------|
| **Triggers** | Push to master (*.md changes) + manual dispatch |
| **Inputs** | Configurable `input_file` and `output_file` with defaults |
| **Conversion** | `pandoc/extra` Docker image with XeLaTeX engine |
| **Styling** | 1" margins, 11pt font, blue links |
| **Artifact** | PDF uploaded with 90-day retention |
| **Branch** | Auto-created: `pdf-update-YYYYMMDD-HHMMSS` |
| **PR** | Auto-created with @dremdem as reviewer |

### Workflow File

`.github/workflows/md-to-pdf.yml`

### Default Values

- Input: `yakovenko_python_en.md`
- Output: `yakovenko_python_en_latest.pdf`

### Manual Trigger

Can be run manually from Actions tab with custom input/output files.

## Test Plan

- [ ] Merge PR
- [ ] Run workflow manually from Actions tab
- [ ] Verify PDF is generated correctly
- [ ] Verify PR is created with correct reviewer

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)