### PR TITLE
Add custom LaTeX template for ATS-friendly PDF

### DIFF
--- a/.github/workflows/md-to-pdf.yml
+++ b/.github/workflows/md-to-pdf.yml
@@ -36,10 +36,7 @@ jobs:
             ${{ env.INPUT_FILE }}
             -o ${{ env.OUTPUT_FILE }}
             --pdf-engine=xelatex
-            -V geometry:margin=1in
-            -V fontsize=11pt
-            -V linkcolor=blue
-            -V urlcolor=blue
+            --template=templates/resume.tex
             --highlight-style=tango
 
       - name: Upload PDF artifact
@@ -84,8 +81,9 @@ jobs:
 
           ### Generated with Pandoc
           - Engine: XeLaTeX
+          - Template: Custom ATS-friendly (templates/resume.tex)
+          - Font: Liberation Sans
           - Margins: 1 inch
-          - Font size: 11pt
 
           ---
           *This PR was automatically created by the MD to PDF workflow.*" \

--- a/templates/resume.tex
+++ b/templates/resume.tex
@@ -1,0 +1,83 @@
+% Custom LaTeX template for ATS-friendly resume PDF
+% Uses Liberation Sans font (Arial equivalent)
+% Pandoc template for XeLaTeX
+
+\documentclass[11pt,a4paper]{article}
+
+% Page geometry - 1 inch margins
+\usepackage[margin=1in]{geometry}
+
+% Font configuration - Liberation Sans (ATS-friendly, Arial-like)
+\usepackage{fontspec}
+\setmainfont{Liberation Sans}
+\setsansfont{Liberation Sans}
+
+% Remove paragraph indentation
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{0.5em}
+
+% Section header styling - bold with line below
+\usepackage{titlesec}
+\titleformat{\section}
+  {\normalfont\Large\bfseries}
+  {}
+  {0pt}
+  {}
+  [\titlerule]
+\titlespacing*{\section}{0pt}{1.5em}{0.75em}
+
+\titleformat{\subsection}
+  {\normalfont\large\bfseries}
+  {}
+  {0pt}
+  {}
+\titlespacing*{\subsection}{0pt}{1em}{0.5em}
+
+\titleformat{\subsubsection}
+  {\normalfont\normalsize\bfseries}
+  {}
+  {0pt}
+  {}
+\titlespacing*{\subsubsection}{0pt}{0.75em}{0.25em}
+
+% Hyperlink configuration
+\usepackage{hyperref}
+\hypersetup{
+  colorlinks=true,
+  linkcolor=blue,
+  urlcolor=blue,
+  pdfborder={0 0 0}
+}
+
+% List styling - tighter spacing
+\usepackage{enumitem}
+\setlist[itemize]{nosep, leftmargin=1.5em}
+\setlist[enumerate]{nosep, leftmargin=1.5em}
+
+% Disable page numbers for single-page resume (optional)
+% \pagenumbering{gobble}
+
+% Better typography
+\usepackage{microtype}
+
+% For tight lists from Pandoc
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+
+% Begin document
+\begin{document}
+
+$if(title)$
+{\huge\bfseries $title$}
+$endif$
+
+$if(subtitle)$
+\vspace{0.25em}
+{\Large $subtitle$}
+$endif$
+
+\vspace{1em}
+
+$body$
+
+\end{document}


### PR DESCRIPTION
## Summary

Adds a custom LaTeX template for professional, ATS-friendly PDF output per #4.

### Template Settings

| Setting | Value | Reason |
|---------|-------|--------|
| **Font** | Liberation Sans | Open-source Arial equivalent, ATS-friendly |
| **Margins** | 1 inch | Standard professional margins |
| **Section headers** | Bold + horizontal line | Clear visual hierarchy |
| **List spacing** | Tight/compact | More content per page |
| **Links** | Blue, no underline | Professional appearance |
| **Paragraph indent** | None | Modern resume style |

### Files Changed

- `templates/resume.tex` - New custom LaTeX template
- `.github/workflows/md-to-pdf.yml` - Updated to use `--template=templates/resume.tex`

### Template Features

```latex
% Font: Liberation Sans (Arial-like, ATS-friendly)
\setmainfont{Liberation Sans}

% Section headers with line below
\titleformat{\section}{\Large\bfseries}{}{}{}[\titlerule]

% Tight list spacing
\setlist[itemize]{nosep, leftmargin=1.5em}
```

### Before/After

| Aspect | Before | After |
|--------|--------|-------|
| Font | Computer Modern (academic) | Liberation Sans (professional) |
| Headers | Plain bold | Bold + underline |
| Control | Pandoc variables | Full LaTeX template |

## Test Plan

- [x] Merge PR
- [x] Run workflow manually from Actions tab
- [ ] Download PDF artifact and verify:
  - [ ] Liberation Sans font renders
  - [ ] Section headers have lines below
  - [ ] 1" margins applied
  - [ ] Links are blue

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)